### PR TITLE
Make it easier to use GHCJSi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ backend/static
 *.js_hi
 *.js_o
 *.sqlite3
+frontend/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 FRONTEND_STACK_PATH=$(shell cd frontend && stack path --dist-dir)/build/frontend-output/frontend-output.jsexe/
-# NODE_PATH=/usr/local/lib/node_modules
 
 build: frontend backend
 
@@ -12,7 +11,8 @@ frontend-watch:
 	cd frontend && stack build --file-watch --fast
 
 ghcjsi:
-	cd frontend && NODE_PATH=$(NODE_PATH) stack ghci
+	cd frontend && ([ -d node_modules ] || npm install socket.io)
+	cd frontend && NODE_PATH=./node_modules stack ghci
 
 backend:
 	cd backend && stack build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ frontend-watch:
 	cd frontend && stack build --file-watch --fast
 
 ghcjsi:
-	cd frontend && NODE_PATH=$(NODE_PATH) stack exec -- ghcjs --interactive
+	cd frontend && NODE_PATH=$(NODE_PATH) stack ghci
 
 backend:
 	cd backend && stack build

--- a/README.md
+++ b/README.md
@@ -32,15 +32,23 @@ $ make frontend-watch
 
 Keep in mind `GHCJSi` hasn't had quite as much time to get a shake-out as `GHCi` so if you run into any issues, _please_ report it to [the GHCJS project](https://github.com/ghcjs/ghcjs)!
 
-```
-$ cd frontend && stack ghci
-```
-
-If the version of stack is below 1.2.0, it's possible that the above commands don't work.
-If the commands above didn't work, you could try the following commands.
+First go to frontend directory.
 
 ```
-$ cd frontend && stack exec -- ghcjs --interactive
+$ cd frontend
+```
+
+Then, launch REPL.
+
+```
+$ stack ghci
+```
+
+If the version of stack is below 1.2.0, it's possible that the above command doesn't work.
+If the command above didn't work, you could try the following command.
+
+```
+$ stack exec -- ghcjs --interactive
 ```
 
 You should see a warning about:
@@ -52,13 +60,13 @@ socket.io not found, browser session not available
 Install socket.io with Node.js:
 
 ```
-$ sudo npm install -g socket.io
+$ npm install socket.io
 ```
 
-Then set your `NODE_PATH` so GHCJS can find your node packages. My global `node_modules` is in `/usr/local/lib`, so it looked like:
+Then export `NODE_PATH` permanently for the current shell session, so GHCJS can find your node packages.
 
 ```
-export NODE_PATH=/usr/local/lib/node_modules
+export NODE_PATH=$(pwd)/node_modules
 ```
 
 Then starting GHCJS should be free of the socket.io warning:
@@ -66,16 +74,24 @@ Then starting GHCJS should be free of the socket.io warning:
 ```
 $ stack ghci
 GHCJSi, version 0.2.0-7.10.3: http://www.github.com/ghcjs/ghcjs/  :? for help
-Prelude> 
+Prelude>
 ```
 
-Then connect your browser to the exposed web server at `localhost:6400`, and load the `src` dir to see it in action. There'll be a slight delay the first time you `GHCJSi` to evaluate something, but then it should work fine:
+Alternatively, instead of exporting `NODE_PATH`, you could execute the following command
 
 ```
-Prelude> :l src/Lib.hs 
+$ NODE_PATH=./node_modules stack ghci
+```
+
+If you didn't want to care about installing socket.io and setting `NODE_PATH`, you could just execute `make ghcjsi` in the directory that contains `Makefile`.
+
+Now, connect your browser to the exposed web server at `localhost:6400`, and load the `src` dir to see it in action. There'll be a slight delay the first time you `GHCJSi` to evaluate something, but then it should work fine:
+
+```
+Prelude> :l src/Lib.hs
 [1 of 1] Compiling Lib              ( src/Lib.hs, interpreted )
 Ok, modules loaded: Lib.
-*Lib> :set -XOverloadedStrings 
+*Lib> :set -XOverloadedStrings
 *Lib> console_log "blah"
 *Lib>
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ $ make frontend-watch
 
 Keep in mind `GHCJSi` hasn't had quite as much time to get a shake-out as `GHCi` so if you run into any issues, _please_ report it to [the GHCJS project](https://github.com/ghcjs/ghcjs)!
 
+```
+$ cd frontend && stack ghci
+```
+
+If the version of stack is below 1.2.0, it's possible that the above commands don't work.
+If the commands above didn't work, you could try the following commands.
 
 ```
 $ cd frontend && stack exec -- ghcjs --interactive
@@ -58,7 +64,7 @@ export NODE_PATH=/usr/local/lib/node_modules
 Then starting GHCJS should be free of the socket.io warning:
 
 ```
-$ stack exec -- ghcjs --interactive           
+$ stack ghci
 GHCJSi, version 0.2.0-7.10.3: http://www.github.com/ghcjs/ghcjs/  :? for help
 Prelude> 
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ make frontend-watch
 
 Keep in mind `GHCJSi` hasn't had quite as much time to get a shake-out as `GHCi` so if you run into any issues, _please_ report it to [the GHCJS project](https://github.com/ghcjs/ghcjs)!
 
-First go to frontend directory.
+First, go to frontend directory.
 
 ```
 $ cd frontend
@@ -63,13 +63,13 @@ Install socket.io with Node.js:
 $ npm install socket.io
 ```
 
-Then export `NODE_PATH` permanently for the current shell session, so GHCJS can find your node packages.
+Then, export `NODE_PATH` permanently for the current shell session, so GHCJS can find your node packages.
 
 ```
 export NODE_PATH=$(pwd)/node_modules
 ```
 
-Then starting GHCJS should be free of the socket.io warning:
+Now, starting GHCJS should be free of the socket.io warning:
 
 ```
 $ stack ghci
@@ -83,7 +83,11 @@ Alternatively, instead of exporting `NODE_PATH`, you could execute the following
 $ NODE_PATH=./node_modules stack ghci
 ```
 
-If you didn't want to care about installing socket.io and setting `NODE_PATH`, you could just execute `make ghcjsi` in the directory that contains `Makefile`.
+If you didn't want to care about installing socket.io and setting `NODE_PATH`, you could just execute the following command in the directory that contains `Makefile`.
+
+```
+$ make ghcjsi
+```
 
 Now, connect your browser to the exposed web server at `localhost:6400`, and load the `src` dir to see it in action. There'll be a slight delay the first time you `GHCJSi` to evaluate something, but then it should work fine:
 

--- a/frontend/stack.yaml
+++ b/frontend/stack.yaml
@@ -3,15 +3,13 @@ packages:
 
 extra-deps: []
 
-# compiler: ghcjs-0.2.0_ghc-7.10.2
-# resolver: ghcjs-0.2.0_ghc-7.10.2
-
-resolver: ghcjs-0.2.0.20160414_ghc-7.10.3
-compiler: ghcjs-0.2.0.20160414_ghc-7.10.3
+resolver: lts-6.20
+compiler: ghcjs-0.2.0.9006020_ghc-7.10.3
 compiler-check: match-exact
+
 setup-info:
   ghcjs:
     source:
-      ghcjs-0.2.0.20160414_ghc-7.10.3:
-        url: https://s3.amazonaws.com/ghcjs/ghcjs-0.2.0.20160414_ghc-7.10.3.tar.gz
-        sha1: 6d6f307503be9e94e0c96ef1308c7cf224d06be3
+      ghcjs-0.2.0.9006020_ghc-7.10.3:
+        url: http://ghcjs.tolysz.org/lts-6.20-9006020.tar.gz
+        sha1: a6cea90cd8121eee3afb201183c6e9bd6bacd94a


### PR DESCRIPTION
Now, you can just execute `make ghcjsi` to launch GHCJS REPL.